### PR TITLE
CTOOLS-563: Update Luminesce post generation

### DIFF
--- a/generate/fix-files-for-imports.sh
+++ b/generate/fix-files-for-imports.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eETuo pipefail
+
+failure() {
+  local lineno="$1"
+  local msg="$2"
+  echo "Failed at $lineno: $msg"
+}
+trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+
+justfile_dir=$1
+package_name=$2
+application=$3
+
+while read -r item; do
+    echo "item='$item'"
+    file="$(echo "$item" | jq -r '.file')"
+    find="$(echo "$item" | jq -r '.find')"
+    replace="$(echo "$item" | jq -r '.replace')"
+    bash "$justfile_dir/generate/fix-import-for-luminesce.sh" "$justfile_dir/generate/.output/sdk/src/main/java/com/finbourne/$application/model/$file.java" "$find" "$replace"
+done <<< "$(jq -rc '.items[]' "$justfile_dir/generate/luminesce-import-fix-list.json")"

--- a/generate/fix-import-for-luminesce.sh
+++ b/generate/fix-import-for-luminesce.sh
@@ -9,9 +9,9 @@ failure() {
 }
 trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
 
-file=$1 # generate/.output/sdk/src/main/java/com/finbourne/luminesce/model/FilterModel.java
-find=$2 # com.finbourne.luminesce.model.Type; 
-replace=$3 # private com.finbourne.luminesce.model.Type type;
+file=$1
+find=$2
+replace=$3
 
 # need the GNU version of sed on a mac
 if [[ $(uname) == Darwin ]]; then
@@ -25,13 +25,6 @@ if [[ $(uname) == Darwin ]]; then
 fi
 
 echo "Running fix for luminesce"
-
-# Check the exit status
-if [ $? -eq 0 ]; then
-    echo "sed command ran successfully"
-else
-    echo "sed command failed"
-fi
 # check that the expected text exists in the file
 if sed -i "s|$find|$replace|" "$file"; then
     echo "sed command ran successfully, replacement done."

--- a/generate/fix-import-for-luminesce.sh
+++ b/generate/fix-import-for-luminesce.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eETuo pipefail
+
+failure() {
+  local lineno="$1"
+  local msg="$2"
+  echo "Failed at $lineno: $msg"
+}
+trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+
+file=$1 # generate/.output/sdk/src/main/java/com/finbourne/luminesce/model/FilterModel.java
+find=$2 # com.finbourne.luminesce.model.Type; 
+replace=$3 # private com.finbourne.luminesce.model.Type type;
+
+# need the GNU version of sed on a mac
+if [[ $(uname) == Darwin ]]; then
+    if gsed --version > /dev/null; then
+        shopt -s expand_aliases
+        alias sed=gsed
+    else
+        echo "GNU sed required for this script, please add it. See https://formulae.brew.sh/formula/gnu-sed"
+        exit 1
+    fi
+fi
+
+echo "Running fix for luminesce"
+
+# Check the exit status
+if [ $? -eq 0 ]; then
+    echo "sed command ran successfully"
+else
+    echo "sed command failed"
+fi
+# check that the expected text exists in the file
+if sed -i "s|$find|$replace|" "$file"; then
+    echo "sed command ran successfully, replacement done."
+    exit 0
+else
+    echo "Failed to find $find in $file"
+    exit 1
+fi

--- a/generate/luminesce-import-fix-list.json
+++ b/generate/luminesce-import-fix-list.json
@@ -19,6 +19,11 @@
             "file": "FilterModel",
             "find": "private Type type;",
             "replace": "private com.finbourne.luminesce.model.Type type;"
+        },
+        {
+            "file": "FilterModel",
+            "find": "import java.lang.reflect.Type;",
+            "replace": ""
         }
 
     ]

--- a/generate/luminesce-import-fix-list.json
+++ b/generate/luminesce-import-fix-list.json
@@ -2,23 +2,24 @@
     "items": [
         {
             "file": "FilterModel",
-            "find": "'public FilterModel type(Type type)'",
-            "replace": "'public FilterModel type(com.finbourne.luminesce.model.Type type)'"
+            "find": "public FilterModel type(Type type)",
+            "replace": "public FilterModel type(com.finbourne.luminesce.model.Type type)"
         },
         {
             "file": "FilterModel",
-            "find": "'public Type getType()'",
-            "replace": "'public void setType(com.finbourne.luminesce.model.Type type)'"
+            "find": "public Type getType()",
+            "replace": "public com.finbourne.luminesce.model.Type getType()"
         },
         {
             "file": "FilterModel",
-            "find": "'AmazonSqsPrincipalAuth'",
-            "replace": "'AmazonSqsPrincipalAuth'"
+            "find": "public void setType(Type type)",
+            "replace": "public void setType(com.finbourne.luminesce.model.Type type)"
         },
         {
             "file": "FilterModel",
-            "find": "'AmazonSqsPrincipalAuth'",
-            "replace": "'AmazonSqsPrincipalAuth'"
+            "find": "private Type type;",
+            "replace": "private com.finbourne.luminesce.model.Type type;"
         }
+
     ]
 }

--- a/generate/luminesce-import-fix-list.json
+++ b/generate/luminesce-import-fix-list.json
@@ -1,0 +1,24 @@
+{
+    "items": [
+        {
+            "file": "FilterModel",
+            "find": "'public FilterModel type(Type type)'",
+            "replace": "'public FilterModel type(com.finbourne.luminesce.model.Type type)'"
+        },
+        {
+            "file": "FilterModel",
+            "find": "'public Type getType()'",
+            "replace": "'public void setType(com.finbourne.luminesce.model.Type type)'"
+        },
+        {
+            "file": "FilterModel",
+            "find": "'AmazonSqsPrincipalAuth'",
+            "replace": "'AmazonSqsPrincipalAuth'"
+        },
+        {
+            "file": "FilterModel",
+            "find": "'AmazonSqsPrincipalAuth'",
+            "replace": "'AmazonSqsPrincipalAuth'"
+        }
+    ]
+}

--- a/justfile
+++ b/justfile
@@ -62,6 +62,8 @@ generate-local:
     rm -f generate/.output/.openapi-generator-ignore || true
     rm generate/templates/description.mustache
 
+    if [ "{{APPLICATION_NAME}}" = "luminesce" ]; then just make-import-fix; fi
+
     # split the README into two, and move one up a level
     bash generate/split-readme.sh
 
@@ -171,6 +173,7 @@ generate-cicd TARGET_DIR:
     # this prevents deleted content from hanging around indefinitely.
     rm -rf {{TARGET_DIR}}/sdk/${APPLICATION_NAME}
     rm -rf {{TARGET_DIR}}/sdk/docs
+    if [ "{{APPLICATION_NAME}}" = "luminesce" ]; then just make-import-fix; fi
 
     if [ "$EXCLUDE_TESTS" != "false" ]; then rm generate/.output/sdk/pom.dev.xml; fi
     cp -R generate/.output/. {{TARGET_DIR}}
@@ -222,3 +225,9 @@ publish-cicd SRC_DIR:
     # mvn -e -f {{SRC_DIR}}/pom.xml test-compile compile
     mvn -f {{SRC_DIR}}/pom.xml versions:set -DnewVersion=${PACKAGE_VERSION}
     mvn -f {{SRC_DIR}}/pom.xml -s {{SRC_DIR}}/settings.xml clean deploy -Dmaven.test.skip=true ${extra_mvn_commandline_options}
+
+make-import-fix:
+    bash {{justfile_directory()}}/generate/fix-import-for-luminesce.sh \
+    {{justfile_directory()}}/generate/.output/sdk/src/main/java/com/finbourne/luminesce/model/FilterModel.java \
+    "private Type type;" \
+    "private com.finbourne.luminesce.model.Type type;"

--- a/justfile
+++ b/justfile
@@ -9,9 +9,9 @@
 #    META_REQUEST_ID_HEADER_KEY
 #    NUGET_PACKAGE_LOCATION
 
-export APPLICATION_NAME := `echo ${APPLICATION_NAME:-lusid}`
-export PACKAGE_NAME := `echo ${PACKAGE_NAME:-lusid-sdk}`
-export PROJECT_NAME := `echo ${PROJECT_NAME:-lusid}`
+export APPLICATION_NAME := `echo ${APPLICATION_NAME:-luminesce}`
+export PACKAGE_NAME := `echo ${PACKAGE_NAME:-luminesce-sdk}`
+export PROJECT_NAME := `echo ${PROJECT_NAME:-luminesce}`
 export PACKAGE_VERSION := `echo ${PACKAGE_VERSION:-2.9999.0}`
 export META_REQUEST_ID_HEADER_KEY := `echo ${META_REQUEST_ID_HEADER_KEY:-lusid-meta-requestid}`
 export JAVA_PACKAGE_LOCATION := `echo ${JAVA_PACKAGE_LOCATION:-~/.java/maven/local-packages}`
@@ -173,6 +173,7 @@ generate-cicd TARGET_DIR:
     # this prevents deleted content from hanging around indefinitely.
     rm -rf {{TARGET_DIR}}/sdk/${APPLICATION_NAME}
     rm -rf {{TARGET_DIR}}/sdk/docs
+
     if [ "{{APPLICATION_NAME}}" = "luminesce" ]; then just make-import-fix; fi
 
     if [ "$EXCLUDE_TESTS" != "false" ]; then rm generate/.output/sdk/pom.dev.xml; fi

--- a/justfile
+++ b/justfile
@@ -227,7 +227,7 @@ publish-cicd SRC_DIR:
     mvn -f {{SRC_DIR}}/pom.xml -s {{SRC_DIR}}/settings.xml clean deploy -Dmaven.test.skip=true ${extra_mvn_commandline_options}
 
 make-import-fix:
-    bash {{justfile_directory()}}/generate/fix-import-for-luminesce.sh \
-    {{justfile_directory()}}/generate/.output/sdk/src/main/java/com/finbourne/luminesce/model/FilterModel.java \
-    "private Type type;" \
-    "private com.finbourne.luminesce.model.Type type;"
+    bash {{justfile_directory()}}/generate/fix-files-for-imports.sh \
+    {{justfile_directory()}} \
+    ${PACKAGE_NAME} \
+    ${APPLICATION_NAME}


### PR DESCRIPTION

# Description of the PR

Luminesce exports a type called 'Type' this collides with the built Type in Java.
The fix is to qualify the type and remove the built type import.

See passing [pipeline](https://concourse.finbourne.com/teams/client-tech/pipelines/CTOOLS-563-test-sdk-generation?group=luminesce)


