### PR TITLE
CTOOLS-603: Updated templating to support default big decimal types

### DIFF
--- a/generate/templates/pojo.mustache
+++ b/generate/templates/pojo.mustache
@@ -113,7 +113,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/isContainer}}
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
   {{^vendorExtensions.x-is-jackson-optional-nullable}}
-  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{#isDouble}}{{{datatypeWithEnum}}}.valueOf({{{.}}}){{/isDouble}}{{^isDouble}}{{{.}}}{{/isDouble}}{{/defaultValue}};
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}

--- a/justfile
+++ b/justfile
@@ -9,9 +9,9 @@
 #    META_REQUEST_ID_HEADER_KEY
 #    NUGET_PACKAGE_LOCATION
 
-export APPLICATION_NAME := `echo ${APPLICATION_NAME:-luminesce}`
-export PACKAGE_NAME := `echo ${PACKAGE_NAME:-luminesce-sdk}`
-export PROJECT_NAME := `echo ${PROJECT_NAME:-luminesce}`
+export APPLICATION_NAME := `echo ${APPLICATION_NAME:-lusid}`
+export PACKAGE_NAME := `echo ${PACKAGE_NAME:-lusid-sdk}`
+export PROJECT_NAME := `echo ${PROJECT_NAME:-lusid}`
 export PACKAGE_VERSION := `echo ${PACKAGE_VERSION:-2.9999.0}`
 export META_REQUEST_ID_HEADER_KEY := `echo ${META_REQUEST_ID_HEADER_KEY:-lusid-meta-requestid}`
 export JAVA_PACKAGE_LOCATION := `echo ${JAVA_PACKAGE_LOCATION:-~/.java/maven/local-packages}`


### PR DESCRIPTION
# Description of the PR

Updated Java SDK generation to support Big decimal default types.

The project has been tested by locally building Lusid (see successful build) and pipeline for non Lusid SDKs.
The type 1d needs to be converted 

See passing pipelines https://concourse.finbourne.com/teams/client-tech/pipelines/CTOOLS-603-test-sdk-generation?group=trigger-all

![Screenshot 2025-03-25 at 11 25 40](https://github.com/user-attachments/assets/b4d8f4f5-f012-4b15-ac36-36bb92f19aa1)

Before
![Screenshot 2025-03-25 at 11 26 50](https://github.com/user-attachments/assets/2ff8ae9f-6152-4ffb-93d8-793d8ae87da3)


After 
![Screenshot 2025-03-25 at 11 26 06](https://github.com/user-attachments/assets/80c4191e-9038-43ca-bcf0-d087b683ddc6)
